### PR TITLE
ZFlu optimization

### DIFF
--- a/zmed-extensions/zmed-common/src/DicomWebDataSource/index.js
+++ b/zmed-extensions/zmed-common/src/DicomWebDataSource/index.js
@@ -147,7 +147,7 @@ function createDicomWebApi(dicomWebConfig, userAuthenticationService) {
 
             let response = await axios(config);
             if (response.status == 200) {
-              const studies = response.data.map(el => {
+              const studies = response.data.items.map(el => {
                 return el.study_id;
               });
               if (studies.length > 0) {

--- a/zmed-extensions/zmed-common/src/panels/PanelAI.tsx
+++ b/zmed-extensions/zmed-common/src/panels/PanelAI.tsx
@@ -130,6 +130,7 @@ export default function PanelAI({ servicesManager, commandsManager, extensionMan
             .lastIndexOf(true);
           if (lastIndex == -1) {
             setProcessingState(AIState.undefined);
+            sessionStorage.setItem(currentZFluData, JSON.stringify([]));
             return;
           }
           const element = response.data[lastIndex];
@@ -195,8 +196,10 @@ export default function PanelAI({ servicesManager, commandsManager, extensionMan
       setProcessingState(AIState.loading)
       _retrieveData();
     } else {
-      setSeriesData(JSON.parse(sessionStorage.getItem(currentZFluData)))
-      setProcessingState(AIState.finished)
+      const storedData = sessionStorage.getItem(currentZFluData);
+      const diases = storedData ? JSON.parse(storedData) : [];
+      setSeriesData(diases);
+      diases.length > 0 ? setProcessingState(AIState.finished) : setProcessingState(AIState.undefined);
     }
     return () => {
       isMounted.current = false;

--- a/zmed-extensions/zmed-common/src/panels/PanelAI.tsx
+++ b/zmed-extensions/zmed-common/src/panels/PanelAI.tsx
@@ -31,14 +31,19 @@ export default function PanelAI({ servicesManager, commandsManager, extensionMan
     finished,
     finishedWithApply, // данные можем показать, но чтобы обновить рабочий стол, нужно обновить экран
     error,
+    null
   }
-  const [processingState, setProcessingState] = useState(AIState.loading);
+  const [processingState, setProcessingState] = useState(AIState.null);
   const [buttonClicked, setButtonClicked] = useState(false);
   const [seriesData, setSeriesData] = useState([{
     title: '',
     value: '',
   }]);
   const [wasProcessing, setWasProcessing] = useState(false);
+  const StudyInstanceUID =
+      DisplaySetService.activeDisplaySets[0].StudyInstanceUID;
+  const currentZFluData = `ZFluID: ${StudyInstanceUID}`
+  const zFluResults = sessionStorage.getItem(currentZFluData)
   const timer = null || number;
 
   // function checkStatus()
@@ -154,6 +159,7 @@ export default function PanelAI({ servicesManager, commandsManager, extensionMan
             console.log("processed array")
             console.log(array)
             setSeriesData(array);
+            sessionStorage.setItem(currentZFluData, JSON.stringify(array));
             console.log('------- isWasProcessed');
             console.log(wasProcessing);
             if (wasProcessing) {
@@ -177,8 +183,6 @@ export default function PanelAI({ servicesManager, commandsManager, extensionMan
   };
 
   function getSeriesData() {
-    const StudyInstanceUID =
-      DisplaySetService.activeDisplaySets[0].StudyInstanceUID;
     const datasource = extensionManager.getActiveDataSource()[0];
     datasource.retrieve.series.metadata({
       StudyInstanceUID,
@@ -187,7 +191,13 @@ export default function PanelAI({ servicesManager, commandsManager, extensionMan
   }
 
   useEffect(() => {
-    _retrieveData();
+    if (!zFluResults){
+      setProcessingState(AIState.loading)
+      _retrieveData();
+    } else {
+      setSeriesData(JSON.parse(sessionStorage.getItem(currentZFluData)))
+      setProcessingState(AIState.finished)
+    }
     return () => {
       isMounted.current = false;
     };


### PR DESCRIPTION
Добавил функциональность кеширования результатов работы нейросети ZFlu. Они сохраняются в sessionStorage. При открытии вкладки ZFlu по дефолту состояние - null, в useEffect проверяется наличие данных в кэше и есть 2 варианта:
1) В кэше нет данных, тогда state = loading и запускаются сетевые запросы
2) В кэше есть данные, тогда state = finished и эти данные из кэша записываются в seriesData и соответственно рендерятся.
Это позволяет избежать лишних запросов в сеть и предотвращает появление лоадера на мгновение и сразу же ререндер, что неприятно глазам из-за резкости.

По идее не должно быть проблем с использованием sessionStorage потому что там хранятся нечувствительные данные, а поиск элемента происходит за O(1) за счет выбора элемента по ключу.

Вот пример того, что лежит в sessionStorage:
Ключ: ZFluID: 1.2.276.0.7230010.3.1.2.2934743141.8052.1706595757.229
Значение:
[{"title":"Плевральный выпот","value":0},
{"title":"Пневмоторакс","value":0.4290287989398689},
{"title":"Очаг затемнения","value":0},
{"title":"Инфильтрация или консолидация","value":0.21217322675382994},
{"title":"Полость","value":0},
{"title":"Ателектаз","value":0},
{"title":"Кальцинат или кальцинированная тень в легких","value":0},
{"title":"Кардиомегалия","value":0},
{"title":"Нарушение целостности кортикального слоя","value":0},
{"title":"Консолидированный перелом","value":0}]